### PR TITLE
Allow any version exceptions e.g. name@* as used in exceptions.js

### DIFF
--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -10,7 +10,10 @@ function inWhitelist(licenseString) {
 }
 
 function inExceptionList(key) {
-  return exceptions[key]
+  const packageName = key.split('@')[0]
+  const anyVersionKey = `${packageName}@*`
+
+  return exceptions[key] || exceptions[anyVersionKey]
 }
 
 function checkLicenses(licenses) {
@@ -27,14 +30,18 @@ function checkLicenses(licenses) {
     licensed[item.licenses] = (licensed[item.licenses] || 0) + 1
     if (inWhitelist(item.licenses + '')) {
       licensedCount++
-    } else if (inExceptionList(key)) {
-      usedExceptions[key] = exceptions[key]
-      exceptionCount++
     } else {
-      // There's a problem here
-      item.key = key
-      problems.push(item)
-      problemCount++
+      const exception = inExceptionList(key)
+      if (exception) {
+        usedExceptions[key] = exception
+        exceptionCount++
+      }
+      else {
+        // There's a problem here
+        item.key = key
+        problems.push(item)
+        problemCount++
+      }
     }
   })
 


### PR DESCRIPTION
To allow the following exceptions.js file to work as intended:
```js
module.exports = {
  "cosmos-deploy@*": {
    "reason": "Not required, acceptable use for BBC internal deployments"
  },
  "cycle@1.0.3": {
    "reason": "Public Domain; see: https://github.com/dscape/cycle/"
  },
  "map-stream@0.1.0": {
    "reason": "MIT License; see: https://github.com/dominictarr/map-stream"
  },
  "spdx-exceptions@*": {
    "reason": "Public Domain; see https://github.com/kemitchell/spdx-exceptions.json"
  },
  "spdx-license-ids@*": {
    "reason": "Public Domain; see https://github.com/shinnn/spdx-license-ids"
  },
  "ua-parser-js@0.7.17": {
    "reason": "Public Domain; see https://github.com/faisalman/ua-parser-js"
  }
}

```