### PR TITLE
Fixed typo in check-licenses.js

### DIFF
--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -61,7 +61,7 @@ function checkLicenses(licenses) {
       const value = items[item]
       return colors.red([
         `  ${item.key}`,
-        `    License:     ${item.licences}`,
+        `    License:     ${item.licenses}`,
         `    Repository:  ${item.repository}`,
         `    Publisher:   ${item.publisher}`,
         `    Url:         ${item.url}`,


### PR DESCRIPTION
This corrects the output to show the license type rather than 'undefined' for licenses which aren't whitelisted.