### PR TITLE
Change package name to target bbc npm organisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apache2-license-checker",
+  "name": "@bbc/apache2-license-checker",
   "version": "1.1.0",
   "description": "Automated license checker for validating project dependencies for compatable Apache2 licenses.",
   "main": "run.js",


### PR DESCRIPTION
Changing behaviour to publish to the private org, instead of publicly.